### PR TITLE
when job is canceled expose BUILDKITE_JOB_CANCELED env var

### DIFF
--- a/internal/job/executor.go
+++ b/internal/job/executor.go
@@ -112,6 +112,12 @@ func (e *Executor) Run(ctx context.Context) (exitCode int) {
 		case <-e.cancelCh:
 			e.shell.Commentf("Received cancellation signal, interrupting")
 			e.shell.Interrupt()
+			// Expose canceled job env var so the pre-exit hook can access it.
+			// If there is no error this will be unset.
+			e.shell.Env.Set(
+				"BUILDKITE_JOB_CANCELED",
+				"true",
+			)
 			cancel()
 		}
 	}()


### PR DESCRIPTION
[Jira Ticket](https://invoca.atlassian.net/browse/TECH-12886)

## Changes
Expose BUILDKITE_JOB_CANCELED env var that is available in env during cleanup steps


## TODO
Open up issue against upstream

